### PR TITLE
Fix go install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cd "$(go env GOPATH)/src/github.com/pulumi/kubespy"
 dep ensure
 
 # If $GOBIN is not on your path, you'll need to install the library elsewhere.
-go install github.com/pulumi/cmd/kubespy
+go install github.com/pulumi/kubespy/cmd/kubespy
 ```
 
 From here you can simply run `kubespy`.


### PR DESCRIPTION
The old command lead to the following error message:

```bash
$ go install github.com/pulumi/cmd/kubespy
can't load package: package github.com/pulumi/cmd/kubespy: cannot find package "github.com/pulumi/cmd/kubespy" in any of:
	/usr/local/Cellar/go/1.11/libexec/src/github.com/pulumi/cmd/kubespy (from $GOROOT)
	/Users/jscheuermann/go/src/github.com/pulumi/cmd/kubespy (from $GOPATH)
```