### PR TITLE
enable case-insensitivity in kind field

### DIFF
--- a/watch/watch.go
+++ b/watch/watch.go
@@ -31,7 +31,7 @@ func Forever(apiVersion, kind, objID string) (<-chan watch.Event, error) {
 		return nil, err
 	}
 
-	gvk := schema.GroupVersionKind{Group: gv.Group, Version: gv.Version, Kind: kind}
+	gvk := schema.GroupVersionKind{Group: gv.Group, Version: gv.Version, Kind: strings.Title(kind)}
 
 	namespace, name, err := parseObjID(objID)
 	if err != nil {


### PR DESCRIPTION
This addresses one of the concerns presented in #4 

Referencing https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#naming-conventions, it appears safe to assume that all values of type "Kind" will have an initial uppercase character.