### PR TITLE
Restrict replicaSet watch by namespace

### DIFF
--- a/cmd/trace.go
+++ b/cmd/trace.go
@@ -110,7 +110,7 @@ func traceDeployment(namespace, name string) {
 	}
 
 	replicaSetEvents, err := watch.Forever("extensions/v1beta1", "ReplicaSet",
-		watch.ObjectsOwnedBy(name))
+		watch.ObjectsOwnedBy(namespace, name))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -46,11 +46,9 @@ func ThisObject(namespace, name string) Opts {
 	return Opts{watchType: watchByName, namespace: namespace, name: name}
 }
 
-// ObjectsOwnedBy specifies a watch should look for objects owned by `ownerName`. Owner references
-// must refer to objects in the same namespace, so this function does not take `namespace` as an
-// argument.
-func ObjectsOwnedBy(ownerName string) Opts {
-	return Opts{watchType: watchByOwner, ownerName: ownerName}
+// ObjectsOwnedBy specifies a watch should look for objects owned by `ownerName` in `namespace`.
+func ObjectsOwnedBy(namespace, ownerName string) Opts {
+	return Opts{watchType: watchByOwner, namespace: namespace, ownerName: ownerName}
 }
 
 // Opts specifies which objects to watch for (e.g., "called this" or "owned by x").


### PR DESCRIPTION
If the user does not have permission to get replicas sets at the cluster scope,
trace fails with `unknown (get replicasets.extensions)`. Restricting the watch
to the same namespace fixes the issue.
